### PR TITLE
Clang compatibility

### DIFF
--- a/src/NFcore/NFcore.hh
+++ b/src/NFcore/NFcore.hh
@@ -878,7 +878,7 @@ namespace NFcore
 
 
 			static const int NOSTATE = -1;
-			static const int NOBOND = 0;
+			static constexpr nullptr_t NOBOND = nullptr;
 			static const int NOINDEX = -1;
 
 

--- a/src/NFcore/molecule.cpp
+++ b/src/NFcore/molecule.cpp
@@ -34,7 +34,7 @@ Molecule::Molecule(MoleculeType * parentMoleculeType, int listId)
 	this->indexOfBond = new int [numOfComponents];
 	this->hasVisitedBond = new bool [numOfComponents];
 	for(int b=0; b<numOfComponents; b++) {
-		bond[b]=0; indexOfBond[b]=NOBOND;
+		bond[b]=NOBOND; indexOfBond[b]=0;
 		hasVisitedBond[b] = false;
 	}
 

--- a/src/NFinput/NFinput.cpp
+++ b/src/NFinput/NFinput.cpp
@@ -2563,7 +2563,7 @@ TemplateMolecule *NFinput::readPattern(
 								if(allowedStates.find(molName+"_"+compName+"_"+compStateValue)==allowedStates.end()) {
 									cerr<<"You are trying to give a pattern of type '"<<molName<<"', but you gave an "<<endl;
 									cerr<<"invalid state! The state you gave was: '"<<compStateValue<<"'.  Quitting now."<<endl;
-									return false;
+									exit(1);
 								} else {
 									//State is a valid allowed state, so push it onto our list
 									stateConstraint = allowedStates.find(molName+"_"+compName+"_"+compStateValue)->second;
@@ -2591,7 +2591,7 @@ TemplateMolecule *NFinput::readPattern(
 								} catch (std::runtime_error e) {
 									cerr<<"I couldn't parse the numberOfBonds value when creating pattern: "<<patternName<<endl;
 									cerr<<e.what()<<endl;
-									return false;
+									exit(1);
 								}
 
 								if(numOfBondsInt==0) {
@@ -2603,7 +2603,7 @@ TemplateMolecule *NFinput::readPattern(
 								} else {
 									cerr<<"I can only handle a site that has 0 or 1 bonds in pattern: "<<patternName<<endl;
 									cerr<<"You gave me "<<numOfBondsInt<<" instead for component "<<compName<<endl;
-									return false;
+									exit(1);
 								}
 							}
 						}
@@ -2624,7 +2624,7 @@ TemplateMolecule *NFinput::readPattern(
 								if(allowedStates.find(molName+"_"+compName+"_"+compStateValue)==allowedStates.end()) {
 									cerr<<"You are trying to give a pattern of type '"<<molName<<"', but you gave an "<<endl;
 									cerr<<"invalid state! The state you gave was: '"<<compStateValue<<"'.  Quitting now."<<endl;
-									return false;
+									exit(1);
 								} else {
 									//State is a valid allowed state, so push it onto our list
 									int stateValueInt = allowedStates.find(molName+"_"+compName+"_"+compStateValue)->second;
@@ -2634,7 +2634,7 @@ TemplateMolecule *NFinput::readPattern(
 									if(!lookup(symC, compId, comps, symMap)) {
 										cerr<<"Could not find the symmetric component when creating a component state, but there\n";
 										cerr<<"should have been one!!  I don't know what to do, so I'll quit."<<endl;
-										return false;
+										exit(1);
 									}
 									stateName.push_back(symC->symPermutationName);
 									stateValue.push_back(stateValueInt);
@@ -2666,7 +2666,7 @@ TemplateMolecule *NFinput::readPattern(
 								} catch (std::runtime_error e) {
 									cerr<<"I couldn't parse the numberOfBonds value when creating pattern: "<<patternName<<endl;
 									cerr<<e.what()<<endl;
-									return false;
+									exit(1);
 								}
 							}
 
@@ -2677,7 +2677,7 @@ TemplateMolecule *NFinput::readPattern(
 							if(!lookup(symC, compId, comps, symMap)) {
 								cerr<<"Could not find the symmetric component when creating a binding site, but there\n";
 								cerr<<"should have been one!!  I don't know what to do, so I'll quit."<<endl;
-								return false;
+								exit(1);
 							}
 
 							if(numOfBondsInt==MUST_BE_OCCUPIED) {
@@ -2693,7 +2693,7 @@ TemplateMolecule *NFinput::readPattern(
 							} else {
 								cerr<<"I can only handle a site that has 0 or 1 bonds in pattern: "<<patternName<<endl;
 								cerr<<"You gave me "<<numOfBondsInt<<" instead for component "<<compName<<endl;
-								return false;
+								exit(1);
 							}
 						}
 
@@ -2747,7 +2747,7 @@ TemplateMolecule *NFinput::readPattern(
 				string bondId, bSite1, bSite2;
 				if(!pBond->Attribute("id") || !pBond->Attribute("site1") || !pBond->Attribute("site2")) {
 					cerr<<"!! Invalid Bond tag for pattern: "<<patternName<<".  Quitting."<<endl;
-					return false;
+					exit(1);
 				} else {
 					bondId = pBond->Attribute("id");
 					bSite1 = pBond->Attribute("site1");
@@ -2799,7 +2799,7 @@ TemplateMolecule *NFinput::readPattern(
 						cerr<<"!!!!Invalid site value for bond: '"<<bondId<<"' when creating pattern '"<<patternName<<"'. "<<endl;
 						cerr<<"This may be caused because you are adding two bonds to one binding site or because you listed"<<endl;
 						cerr<<"a binding site at the end of the pattern that does not exist.  Quitting"<<endl;
-						return false;
+						exit(1);
 					}
 				} catch (exception& e) {
 
@@ -2810,7 +2810,7 @@ TemplateMolecule *NFinput::readPattern(
 					cerr<<"!!!!Invalid site value for bond: '"<<bondId<<"' when creating pattern '"<<patternName<<"'. "<<endl;
 					cerr<<"This may be caused because you are adding two bonds to one binding site or because you listed"<<endl;
 					cerr<<"a binding site at the end of the pattern that does not exist.  Quitting"<<endl;
-					return false;
+					exit(1);
 				}
 			}
 		}
@@ -2834,7 +2834,7 @@ TemplateMolecule *NFinput::readPattern(
 		} catch (exception& e) {
 			cerr<<"Something went wacky when I was parsing pattern '"<<patternName<<"'."<<endl;
 			cerr<<"It happened as I was trying to add an occupied binding site to a template molecule."<<endl;
-			return false;
+			exit(1);
 		}
 
 
@@ -2920,7 +2920,7 @@ TemplateMolecule *NFinput::readPattern(
 		if(tMolecules.empty()){
 			cerr<<"You have a pattern named "<<patternName<<" that doesn't include any actual patterns!  (Or I just couldn't find any)"<<endl;
 			cerr<<"Therefore, I see no other choice than to quit until you fix the problem."<<endl;
-			return false;
+			exit(1);
 		}
 		TemplateMolecule *finalTemplate = tMolecules.at(0);
 
@@ -2941,7 +2941,7 @@ TemplateMolecule *NFinput::readPattern(
 		return NULL;
 	}
 
-	return false;
+	exit(1);
 }
 
 


### PR DESCRIPTION
Pointer to int comparison was not allowed by clang. Also returning "false" instead of quitting by "exit(1)" was not allowed by clang.
Both issues fixed and tested under clang and gcc under os x.